### PR TITLE
Fixed re-renders of statistics chart list

### DIFF
--- a/src/components/InterfaceStatistics/DeviceStatisticsChart.js
+++ b/src/components/InterfaceStatistics/DeviceStatisticsChart.js
@@ -2,20 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Chart from 'react-apexcharts';
 
-const DeviceStatisticsChart = ({ data, options }) => (
+const DeviceStatisticsChart = ({ chart }) => (
   <div style={{ height: '360px' }}>
-    <Chart series={data} options={options} type="line" height="100%" />
+    <Chart series={chart.data} options={chart.options} type="line" height="100%" />
   </div>
 );
 
 DeviceStatisticsChart.propTypes = {
-  data: PropTypes.instanceOf(Array),
-  options: PropTypes.instanceOf(Object),
-};
-
-DeviceStatisticsChart.defaultProps = {
-  data: [],
-  options: {},
+  chart: PropTypes.instanceOf(Object).isRequired,
 };
 
 export default DeviceStatisticsChart;

--- a/src/components/InterfaceStatistics/index.js
+++ b/src/components/InterfaceStatistics/index.js
@@ -14,13 +14,13 @@ import {
 } from '@coreui/react';
 import { cilOptions } from '@coreui/icons';
 import CIcon from '@coreui/icons-react';
+import eventBus from 'utils/eventBus';
 import StatisticsChartList from './StatisticsChartList';
 import LatestStatisticsModal from './LatestStatisticsModal';
 import styles from './index.module.scss';
 
 const DeviceStatisticsCard = ({ selectedDeviceId }) => {
   const { t } = useTranslation();
-  const [lastRefresh, setLastRefresh] = useState(new Date().toString());
   const [showLatestModal, setShowLatestModal] = useState(false);
 
   const toggleLatestModal = () => {
@@ -28,7 +28,7 @@ const DeviceStatisticsCard = ({ selectedDeviceId }) => {
   };
 
   const refresh = () => {
-    setLastRefresh(new Date().toString());
+    eventBus.dispatch('refreshInterfaceStatistics', { message: 'Refresh interface statistics' });
   };
 
   return (
@@ -55,7 +55,7 @@ const DeviceStatisticsCard = ({ selectedDeviceId }) => {
           </CRow>
         </CCardHeader>
         <CCardBody className={styles.statsBody}>
-          <StatisticsChartList selectedDeviceId={selectedDeviceId} lastRefresh={lastRefresh} />
+          <StatisticsChartList selectedDeviceId={selectedDeviceId} />
         </CCardBody>
       </CCard>
       <LatestStatisticsModal


### PR DESCRIPTION
Reduce re-renders of the StatisticsChartList by:
-Deleting use of a particular useState variable
-Refreshing stats without the use of props
-Combining two props given to the DeviceStatisticsChart